### PR TITLE
add pub-sub support, respective API methods

### DIFF
--- a/build.js
+++ b/build.js
@@ -34,6 +34,7 @@ bundler
   .transform({global: true}, sanitizeManifest)
   .transform('babelify', {
     ...babelConf,
+    global: true,
     only: [
       /^(?:.*\/node_modules\/(?:hyperswarm|hyperswarm-ws|hyperswarm-proxy|debug)\/|(?!.*\/node_modules\/)).*$/,
     ],

--- a/client.js
+++ b/client.js
@@ -23,14 +23,16 @@ async function main() {
   const closeDistribution = distributeDocs(id, repo, repoStore)
   console.log('all repos are up for distribution.')
 
-  process.on('SIGINT', async () => {
+  const shutdown = async () => {
     console.log('closing watchers...')
 
     await closeDistribution()
     await repoStore.destroy()
-
     process.exit(0)
-  })
+  }
+
+  process.on('SIGINT', shutdown)
+  process.on('SIGTERM', shutdown)
 }
 
 main()

--- a/client.js
+++ b/client.js
@@ -16,16 +16,17 @@ async function main() {
   console.log(`read repository with id: ${id}`)
 
   if (docs.length === 0) {
-    const url = repo.create({hello: 'world'})
-    await repoStore.addDoc(id, url)
+    await repoStore.addDoc(
+      id,
+      'http://localhost:9000/document/lhipfj6r9agvao',
+      "Jan's notes"
+    )
   }
 
-  const closeDistribution = distributeDocs(id, repo, repoStore)
+  const closeDistribution = await distributeDocs(id, repo, repoStore)
   console.log('all repos are up for distribution.')
 
   const shutdown = async () => {
-    console.log('closing watchers...')
-
     await closeDistribution()
     await repoStore.destroy()
     process.exit(0)

--- a/examples/browser/index.js
+++ b/examples/browser/index.js
@@ -37,6 +37,8 @@ ${JSON.stringify(data, null, 2)}`)
       }),
     2500
   )
+
+  setTimeout(async () => await subscription.close(), 3500)
 }
 
 main()

--- a/examples/browser/index.js
+++ b/examples/browser/index.js
@@ -6,6 +6,7 @@ async function main() {
   const docUrl = window.location.hash.substr(1)
   console.log(`joining request swarm with doc url: ${docUrl}`)
 
+  // initialize swarm, wait until it's ready
   const swarm = new RequestSwarm(docUrl, {
     handleError: function(err) {
       console.error('Bad error:', err)
@@ -13,8 +14,29 @@ async function main() {
   })
   await new Promise(resolve => swarm.on('ready', resolve))
 
-  console.log(await swarm.getAnnotations())
-  console.log(await swarm.getRelated())
+  // get current peer state
+  console.log(`Current annotations:
+${JSON.stringify(await swarm.getAnnotations(), null, 2)}`)
+  console.log(`Related documents to target:
+${JSON.stringify(await swarm.getRelated(), null, 2)}`)
+
+  // create a subscription
+  const subscription = await swarm.getAnnotations({subscribe: true})
+  subscription.on('pub', data =>
+    console.log(`PUB:
+${JSON.stringify(data, null, 2)}`)
+  )
+  subscription.on('close', () => console.log('PUB closed.'))
+  subscription.on('error', err => console.error('PUB error:', err))
+
+  // trigger subscription with a write action
+  setTimeout(
+    () =>
+      swarm.createAnnotation({
+        foo: 'bar',
+      }),
+    2500
+  )
 }
 
 main()

--- a/lib/discovery/swarm.js
+++ b/lib/discovery/swarm.js
@@ -20,6 +20,7 @@ class DiscoverySwarm extends ProtocolSwarm {
     this.id = uuid()
     this.url = url
     this.target = target
+    this.announcements.set(this.id, this.url)
   }
 
   _createStream() {

--- a/lib/distribution.js
+++ b/lib/distribution.js
@@ -31,6 +31,8 @@ class DocumentDistributor extends ResponseSwarm {
       '/annotations/:id.jsonld',
       this._handleDeleteAnnotation
     )
+
+    this.setHandler('sub', '/annotations.jsonld', this._handleSubAllAnnotations)
   }
 
   _handleGetAllAnnotations = async () => {
@@ -44,6 +46,21 @@ class DocumentDistributor extends ResponseSwarm {
         '@context': 'http://www.w3.org/ns/anno.jsonld',
         type: 'Annotation',
       })),
+    }
+  }
+
+  _handleSubAllAnnotations = (method, path, params, data, subscription) => {
+    const handle = this.repo.watch(this.docUrl, doc => {
+      subscription.emit(
+        'pub',
+        Array.isArray(doc.annotations) ? doc.annotations : []
+      )
+    })
+
+    subscription.on('disconnect', () => handle.close())
+
+    return {
+      code: 'PUB_INIT',
     }
   }
 

--- a/lib/distribution.js
+++ b/lib/distribution.js
@@ -33,6 +33,7 @@ class DocumentDistributor extends ResponseSwarm {
     )
 
     this.setHandler('sub', '/annotations.jsonld', this._handleSubAllAnnotations)
+    this.setHandler('sub', '/related.json', this._handleSubRelated)
   }
 
   _handleGetAllAnnotations = async () => {
@@ -155,6 +156,24 @@ class DocumentDistributor extends ResponseSwarm {
     code: 'OK',
     data: this.discovery.uniqueAnnouncements,
   })
+
+  _handleSubRelated = (method, path, params, data, subscription) => {
+    const handleAnnouncementChange = () => {
+      subscription.emit('pub', this.discovery.uniqueAnnouncements)
+    }
+
+    this.discovery.on('announce', handleAnnouncementChange)
+    this.discovery.on('unannounce', handleAnnouncementChange)
+
+    subscription.on('disconnect', () => {
+      this.discovery.removeListener('announce', handleAnnouncementChange)
+      this.discovery.removeListener('unannounce', handleAnnouncementChange)
+    })
+
+    return {
+      code: 'PUB_INIT',
+    }
+  }
 
   async destroy() {
     await this.discovery.destroy()

--- a/lib/distribution.js
+++ b/lib/distribution.js
@@ -162,21 +162,18 @@ class DocumentDistributor extends ResponseSwarm {
   }
 }
 
-function distributeDocs(repoId, repo, repoStore) {
+async function distributeDocs(repoId, repo, repoStore) {
   const docs = repoStore.getDocs(repoId)
-  for (const docUrl of docs) {
-    // TODO fixme when web annotation data model parsing established
-    const target = docUrl
-
+  const announceDoc = async docUrl => {
+    const {target} = await repo.doc(docUrl)
     swarms.set(docUrl, new DocumentDistributor(repo, target, docUrl))
   }
 
-  repoStore.on('doc-added', docUrl => {
-    // TODO fixme when web annotation data model parsing established
-    const target = docUrl
+  for (const docUrl of docs) {
+    await announceDoc(docUrl)
+  }
 
-    swarms.set(docUrl, new DocumentDistributor(repo, target, docUrl))
-  })
+  repoStore.on('doc-added', announceDoc)
 
   repoStore.on('doc-removed', async docUrl => {
     const swarm = swarms.get(docUrl)

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -21,6 +21,7 @@ exports.RequestMethod = {
   PUT: 3,
   DELETE: 4,
   SUB: 5,
+  CLOSE: 6,
 }
 
 exports.ResponseCode = {
@@ -151,7 +152,7 @@ function defineDiscoveryEvent() {
 }
 
 function defineRequestEvent() {
-  var enc = [encodings.enum, encodings.string, encodings.bytes]
+  var enc = [encodings.enum, encodings.bytes, encodings.string]
 
   RequestEvent.encodingLength = encodingLength
   RequestEvent.encode = encode
@@ -162,11 +163,14 @@ function defineRequestEvent() {
     if (!defined(obj.method)) throw new Error('method is required')
     var len = enc[0].encodingLength(obj.method)
     length += 1 + len
+    if (!defined(obj.id)) throw new Error('id is required')
+    var len = enc[1].encodingLength(obj.id)
+    length += 1 + len
     if (!defined(obj.path)) throw new Error('path is required')
-    var len = enc[1].encodingLength(obj.path)
+    var len = enc[2].encodingLength(obj.path)
     length += 1 + len
     if (defined(obj.data)) {
-      var len = enc[2].encodingLength(obj.data)
+      var len = enc[1].encodingLength(obj.data)
       length += 1 + len
     }
     return length
@@ -180,14 +184,18 @@ function defineRequestEvent() {
     buf[offset++] = 8
     enc[0].encode(obj.method, buf, offset)
     offset += enc[0].encode.bytes
-    if (!defined(obj.path)) throw new Error('path is required')
+    if (!defined(obj.id)) throw new Error('id is required')
     buf[offset++] = 18
-    enc[1].encode(obj.path, buf, offset)
+    enc[1].encode(obj.id, buf, offset)
     offset += enc[1].encode.bytes
+    if (!defined(obj.path)) throw new Error('path is required')
+    buf[offset++] = 26
+    enc[2].encode(obj.path, buf, offset)
+    offset += enc[2].encode.bytes
     if (defined(obj.data)) {
-      buf[offset++] = 26
-      enc[2].encode(obj.data, buf, offset)
-      offset += enc[2].encode.bytes
+      buf[offset++] = 34
+      enc[1].encode(obj.data, buf, offset)
+      offset += enc[1].encode.bytes
     }
     encode.bytes = offset - oldOffset
     return buf
@@ -201,14 +209,17 @@ function defineRequestEvent() {
     var oldOffset = offset
     var obj = {
       method: 1,
+      id: null,
       path: '',
       data: null,
     }
     var found0 = false
     var found1 = false
+    var found2 = false
     while (true) {
       if (end <= offset) {
-        if (!found0 || !found1) throw new Error('Decoded message is not valid')
+        if (!found0 || !found1 || !found2)
+          throw new Error('Decoded message is not valid')
         decode.bytes = offset - oldOffset
         return obj
       }
@@ -222,13 +233,18 @@ function defineRequestEvent() {
           found0 = true
           break
         case 2:
-          obj.path = enc[1].decode(buf, offset)
+          obj.id = enc[1].decode(buf, offset)
           offset += enc[1].decode.bytes
           found1 = true
           break
         case 3:
-          obj.data = enc[2].decode(buf, offset)
+          obj.path = enc[2].decode(buf, offset)
           offset += enc[2].decode.bytes
+          found2 = true
+          break
+        case 4:
+          obj.data = enc[1].decode(buf, offset)
+          offset += enc[1].decode.bytes
           break
         default:
           offset = skip(prefix & 7, buf, offset)
@@ -238,7 +254,7 @@ function defineRequestEvent() {
 }
 
 function defineResponseEvent() {
-  var enc = [encodings.enum, encodings.string, encodings.bytes]
+  var enc = [encodings.enum, encodings.bytes, encodings.string]
 
   ResponseEvent.encodingLength = encodingLength
   ResponseEvent.encode = encode
@@ -250,11 +266,14 @@ function defineResponseEvent() {
       var len = enc[0].encodingLength(obj.code)
       length += 1 + len
     }
+    if (!defined(obj.id)) throw new Error('id is required')
+    var len = enc[1].encodingLength(obj.id)
+    length += 1 + len
     if (!defined(obj.path)) throw new Error('path is required')
-    var len = enc[1].encodingLength(obj.path)
+    var len = enc[2].encodingLength(obj.path)
     length += 1 + len
     if (defined(obj.data)) {
-      var len = enc[2].encodingLength(obj.data)
+      var len = enc[1].encodingLength(obj.data)
       length += 1 + len
     }
     return length
@@ -269,14 +288,18 @@ function defineResponseEvent() {
       enc[0].encode(obj.code, buf, offset)
       offset += enc[0].encode.bytes
     }
-    if (!defined(obj.path)) throw new Error('path is required')
+    if (!defined(obj.id)) throw new Error('id is required')
     buf[offset++] = 18
-    enc[1].encode(obj.path, buf, offset)
+    enc[1].encode(obj.id, buf, offset)
     offset += enc[1].encode.bytes
+    if (!defined(obj.path)) throw new Error('path is required')
+    buf[offset++] = 26
+    enc[2].encode(obj.path, buf, offset)
+    offset += enc[2].encode.bytes
     if (defined(obj.data)) {
-      buf[offset++] = 26
-      enc[2].encode(obj.data, buf, offset)
-      offset += enc[2].encode.bytes
+      buf[offset++] = 34
+      enc[1].encode(obj.data, buf, offset)
+      offset += enc[1].encode.bytes
     }
     encode.bytes = offset - oldOffset
     return buf
@@ -290,13 +313,15 @@ function defineResponseEvent() {
     var oldOffset = offset
     var obj = {
       code: 1,
+      id: null,
       path: '',
       data: null,
     }
     var found1 = false
+    var found2 = false
     while (true) {
       if (end <= offset) {
-        if (!found1) throw new Error('Decoded message is not valid')
+        if (!found1 || !found2) throw new Error('Decoded message is not valid')
         decode.bytes = offset - oldOffset
         return obj
       }
@@ -309,13 +334,18 @@ function defineResponseEvent() {
           offset += enc[0].decode.bytes
           break
         case 2:
-          obj.path = enc[1].decode(buf, offset)
+          obj.id = enc[1].decode(buf, offset)
           offset += enc[1].decode.bytes
           found1 = true
           break
         case 3:
-          obj.data = enc[2].decode(buf, offset)
+          obj.path = enc[2].decode(buf, offset)
           offset += enc[2].decode.bytes
+          found2 = true
+          break
+        case 4:
+          obj.data = enc[1].decode(buf, offset)
+          offset += enc[1].decode.bytes
           break
         default:
           offset = skip(prefix & 7, buf, offset)

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -20,16 +20,21 @@ exports.RequestMethod = {
   POST: 2,
   PUT: 3,
   DELETE: 4,
+  SUB: 5,
 }
 
 exports.ResponseCode = {
   OK: 1,
-  NOT_FOUND: 2,
-  BAD_REQUEST: 3,
-  CREATED: 4,
-  UPDATED: 5,
-  DELETED: 6,
+  CREATED: 2,
+  UPDATED: 3,
+  DELETED: 4,
+  NOT_FOUND: 5,
+  BAD_REQUEST: 6,
   INTERNAL_ERROR: 7,
+  PUB_INIT: 8,
+  PUB_DATA: 9,
+  PUB_CLOSE: 10,
+  PUB_ERROR: 11,
 }
 
 var DiscoveryEvent = (exports.DiscoveryEvent = {

--- a/lib/protocol-swarm.js
+++ b/lib/protocol-swarm.js
@@ -9,6 +9,7 @@ class ProtocolSwarm extends AbstractSwarm {
       ...opts,
       swarm: Hyperswarm({
         maxPeers: MAX_PEERS,
+        announceLocalAddress: process.env.NODE_ENV !== 'production',
       }),
     })
   }

--- a/lib/repo-store.js
+++ b/lib/repo-store.js
@@ -89,14 +89,22 @@ class RepoStore extends EventEmitter {
     return entry
   }
 
-  async addDoc(id, docUrl) {
+  async addDoc(id, target, title) {
     const entry = this.repos.get(id)
-
-    if (entry.docs.indexOf(docUrl) === -1) {
-      entry.docs.push(docUrl)
-      await this._saveRepos()
-      this.emit('doc-added', id, docUrl)
+    const notebook = {
+      target,
+      annotations: [],
     }
+    if (title) {
+      notebook.title = title
+    }
+
+    const docUrl = await entry.repo.create(notebook)
+    entry.docs.push(docUrl)
+    await this._saveRepos()
+    this.emit('doc-added', id, docUrl)
+
+    return docUrl
   }
 
   getDocs(id) {

--- a/lib/request/abstract-swarm.js
+++ b/lib/request/abstract-swarm.js
@@ -12,6 +12,7 @@ const requestTypeMapping = {
   POST: 'CREATED',
   PUT: 'UPDATED',
   DELETE: 'DELETED',
+  CLOSE: 'OK',
 }
 
 const decodeData = data =>
@@ -187,11 +188,11 @@ class AbstractRequestSwarm extends AbstractSwarm {
   }
 
   _createSubscription(stream, requestId, requestPath) {
-    /* FIXME: make `subscription.close()` send a CLOSE request to make the
-        server close too! */
     const subscription = new EventEmitter()
-    subscription.close = () => {
+    subscription.close = async () => {
+      debug(`closing subscription ${requestId.toString()}`)
       stream.removeListener('response', handleResponse)
+      subscription.removeAllListeners()
     }
 
     const handleResponse = ({code, id, path, data}) => {

--- a/lib/request/abstract-swarm.js
+++ b/lib/request/abstract-swarm.js
@@ -47,6 +47,7 @@ class AbstractRequestSwarm extends AbstractSwarm {
       swarm,
     })
     this.docUrl = docUrl
+    this.setMaxListeners(256)
   }
 
   async getAnnotations(opts = {}) {

--- a/lib/request/abstract-swarm.js
+++ b/lib/request/abstract-swarm.js
@@ -1,4 +1,5 @@
-const assert = require('assert')
+const uuid = require('uuid/v1')
+const EventEmitter = require('events')
 const {AbstractSwarm} = require('../abstract-swarm')
 const {RequestStream} = require('./stream')
 const {ResponseCode} = require('../messages')
@@ -7,6 +8,7 @@ const debug = require('debug')('me2u:request-swarm')
 
 const requestTypeMapping = {
   GET: 'OK',
+  SUB: 'PUB_INIT',
   POST: 'CREATED',
   PUT: 'UPDATED',
   DELETE: 'DELETED',
@@ -33,7 +35,6 @@ class AbstractRequestSwarm extends AbstractSwarm {
   lastConnectionId = 0
   connections = new Map()
 
-  lastRequestId = 0
   currentRequestId = null
   requestQueue = new Map()
 
@@ -48,12 +49,18 @@ class AbstractRequestSwarm extends AbstractSwarm {
     this.docUrl = docUrl
   }
 
-  async getAnnotations() {
-    return await this.createRequest('get', '/annotations.jsonld')
+  async getAnnotations(opts = {}) {
+    return await this.createRequest(
+      opts.subscribe === true ? 'sub' : 'get',
+      '/annotations.jsonld'
+    )
   }
 
-  async getAnnotation(id) {
-    return await this.createRequest('get', `/annotations/${id}.jsonld`)
+  async getAnnotation(id, opts = {}) {
+    return await this.createRequest(
+      opts.subscribe === true ? 'sub' : 'get',
+      `/annotations/${id}.jsonld`
+    )
   }
 
   async createAnnotation(annotation) {
@@ -86,7 +93,7 @@ class AbstractRequestSwarm extends AbstractSwarm {
   }
 
   createRequest(method, path, data = null) {
-    const requestId = this.lastRequestId++
+    const requestId = Buffer.from(uuid())
     this.requestQueue.set(requestId, {method, path, data})
 
     if (this.currentRequestId === null && this.connections.size > 0) {
@@ -155,6 +162,8 @@ class AbstractRequestSwarm extends AbstractSwarm {
     }
   }
 
+  /* FIXME: as we introduced request IDs, we could also work the queue in
+      in parallel and not sequentially for a higher throughput. */
   async _workQueue(connectionId) {
     for (const [
       requestId,
@@ -165,7 +174,7 @@ class AbstractRequestSwarm extends AbstractSwarm {
       const {createRequest} = this.connections.get(connectionId)
 
       try {
-        const res = await createRequest(method, path, data)
+        const res = await createRequest(method, requestId, path, data)
         this.emit('processed-request', null, requestId, res)
       } catch (err) {
         this.emit('processed-request', err, requestId)
@@ -176,14 +185,66 @@ class AbstractRequestSwarm extends AbstractSwarm {
     this.currentRequestId = null
   }
 
-  _createRequestMethod(stream) {
-    return (method, path, data) =>
-      new Promise((resolve, reject) => {
-        const reqMethod = method.toUpperCase()
-        const goodCode = ResponseCode[requestTypeMapping[reqMethod]]
+  _createSubscription(stream, requestId, requestPath) {
+    /* FIXME: make `subscription.close()` send a CLOSE request to make the
+        server close too! */
+    const subscription = new EventEmitter()
+    subscription.close = () => {
+      stream.removeListener('response', handleResponse)
+    }
 
-        debug(`${reqMethod} ${path}`)
-        stream.once('response', ({code, path, data}) => {
+    const handleResponse = ({code, id, path, data}) => {
+      const responseCode = responseMessage(code)
+      if (
+        !['PUB_DATA', 'PUB_CLOSE', 'PUB_ERROR'].includes(responseCode) ||
+        !requestId.equals(id) ||
+        requestPath !== path
+      ) {
+        return
+      }
+
+      const decodedData = decodeData(data)
+      switch (responseCode) {
+        case 'PUB_DATA':
+          subscription.emit('pub', decodedData)
+          break
+
+        case 'PUB_CLOSE':
+          subscription.emit('close')
+          subscription.close()
+          break
+
+        case 'PUB_ERROR':
+          subscription.emit('error', decodedData)
+          subscription.close()
+          break
+
+        default:
+          break
+      }
+    }
+
+    stream.on('response', handleResponse)
+    stream.once('close', () => {
+      subscription.emit('close')
+      subscription.close()
+    })
+
+    return subscription
+  }
+
+  _createRequestMethod(stream) {
+    return (method, requestId, path, data) =>
+      new Promise((resolve, reject) => {
+        const requestMethod = method.toUpperCase()
+        const goodCode = ResponseCode[requestTypeMapping[requestMethod]]
+
+        const handleResponse = ({code, id, path, data}) => {
+          if (!requestId.equals(id)) {
+            return
+          }
+          stream.removeListener('response', handleResponse)
+
           const decodedData = decodeData(data)
           if (code !== goodCode) {
             reject(
@@ -196,10 +257,18 @@ class AbstractRequestSwarm extends AbstractSwarm {
             )
             return
           }
-          resolve(decodedData)
-        })
 
-        stream.request(reqMethod, path, data)
+          if (responseMessage(code) === 'PUB_INIT') {
+            resolve(this._createSubscription(stream, id, path))
+          } else {
+            resolve(decodedData)
+          }
+        }
+
+        debug(`${requestMethod} ${path}`)
+        stream.on('response', handleResponse)
+
+        stream.request(requestMethod, requestId, path, data)
       })
   }
 }

--- a/lib/request/abstract-swarm.js
+++ b/lib/request/abstract-swarm.js
@@ -82,8 +82,11 @@ class AbstractRequestSwarm extends AbstractSwarm {
     return await this.createRequest('delete', `/annotations/${id}.jsonld`)
   }
 
-  async getRelated() {
-    return await this.createRequest('get', '/related.json')
+  async getRelated(opts = {}) {
+    return await this.createRequest(
+      opts.subscribe === true ? 'sub' : 'get',
+      '/related.json'
+    )
   }
 
   get firstConnectionId() {

--- a/lib/request/stream.js
+++ b/lib/request/stream.js
@@ -12,17 +12,18 @@ class Stream extends Duplex {
     this.setMaxListeners(256)
   }
 
-  request(method, path, data) {
+  request(method, id, path, data) {
     const requestData =
       typeof data === 'object' ? Buffer.from(JSON.stringify(data)) : null
 
-    this._sendMessage(method, path, requestData)
+    this._sendMessage(method, id, path, requestData)
   }
 
-  _sendMessage(method, path, data = null) {
+  _sendMessage(method, id, path, data = null) {
     this.push(
       RequestEvent.encode({
         method: RequestMethod[method],
+        id,
         path,
         data,
       })

--- a/lib/response/stream.js
+++ b/lib/response/stream.js
@@ -13,20 +13,21 @@ class Stream extends Duplex {
     this.setMaxListeners(256)
   }
 
-  respond(code, path, data = null) {
+  respond(code, id, path, data = null) {
     const responseData =
       data && typeof data === 'object'
         ? Buffer.from(JSON.stringify(data))
         : null
 
-    this._sendMessage(code, path, responseData)
+    this._sendMessage(code, id, path, responseData)
   }
 
-  _sendMessage(code, path, data = null) {
-    debug(code, path, data ? '<data>' : '')
+  _sendMessage(code, id, path, data = null) {
+    debug(code, id.toString(), path, data ? '<data>' : '')
     this.push(
       ResponseEvent.encode({
         code: ResponseCode[code],
+        id,
         path,
         data,
       })

--- a/lib/response/stream.js
+++ b/lib/response/stream.js
@@ -13,7 +13,7 @@ class Stream extends Duplex {
     this.setMaxListeners(256)
   }
 
-  respond(code, path, data) {
+  respond(code, path, data = null) {
     const responseData =
       data && typeof data === 'object'
         ? Buffer.from(JSON.stringify(data))

--- a/lib/response/swarm.js
+++ b/lib/response/swarm.js
@@ -1,3 +1,5 @@
+const uuid = require('uuid/v1')
+const EventEmitter = require('events')
 const pathMatch = require('path-match')
 const {ProtocolSwarm} = require('../protocol-swarm')
 const {ResponseStream} = require('./stream')
@@ -34,53 +36,88 @@ class Swarm extends ProtocolSwarm {
 
   _createStream() {
     const stream = new ResponseStream()
-    stream.on('request', ({method, path, data}) =>
-      this._handleRequest(stream, method, path, data)
+    stream.on('request', ({method, id, path, data}) =>
+      this._handleRequest(stream, method, id, path, data)
     )
 
     return stream
   }
 
-  _handleRequest = async (stream, reqMethod, path, data) => {
+  _createSubscription(stream, requestId, path) {
+    const emitter = new EventEmitter()
+    emitter.on('pub', data => stream.respond('PUB_DATA', requestId, path, data))
+    emitter.on('close', () => stream.respond('PUB_CLOSE', requestId, path))
+    emitter.on('error', (data = null) =>
+      stream.respond('PUB_ERROR', requestId, data)
+    )
+
+    /* FIXME: well, this won't work when a subscription is closed, but the
+        stream is kept alive. rather react to `CLOSE` <id> <path> requests from
+        the client and close the subscription then. */
+    stream.on('close', () => emitter.emit('disconnect'))
+
+    return emitter
+  }
+
+  _handleRequest = async (stream, requestMethod, requestId, path, data) => {
     try {
       data = data.length > 0 ? JSON.parse(Buffer.from(data).toString()) : null
     } catch (err) {
-      stream.respond('BAD_REQUEST', path, null)
+      stream.respond('BAD_REQUEST', requestId, path)
       return
     }
 
     if (!path.startsWith('/')) {
-      stream.respond('BAD_REQUEST', path, null)
+      stream.respond('BAD_REQUEST', requestId, path)
       return
     }
 
     for (const {method, matchUrl, handler} of this.handlers) {
       const params = matchUrl(path)
       if (
-        reqMethod === RequestMethod[method.toUpperCase()] &&
+        requestMethod === RequestMethod[method.toUpperCase()] &&
         params !== false
       ) {
-        debug(reqMethod, path, params)
+        debug(requestMethod, requestId.toString(), path, params)
         try {
-          const res = await handler(reqMethod, path, params, data)
+          if (method.toUpperCase() === 'SUB') {
+            stream.respond('PUB_INIT', requestId, path)
+            const subscription = this._createSubscription(
+              stream,
+              requestId,
+              path
+            )
 
-          if (!res) {
-            stream.respond('OK', path, null)
+            try {
+              await handler(requestMethod, path, params, data, subscription)
+            } catch (err) {
+              debug(
+                `an error occured during subscription for request ${requestId.toString()}:`,
+                err
+              )
+              subscription.emit('disconnect')
+            }
           } else {
-            const code = res.code || 'OK'
-            const data = res.data || null
+            const res = await handler(requestMethod, path, params, data)
 
-            stream.respond(code, path, data)
+            if (!res) {
+              stream.respond('OK', requestId, path, null)
+            } else {
+              const code = res.code || 'OK'
+              const data = res.data || null
+
+              stream.respond(code, requestId, path, data)
+            }
           }
         } catch (err) {
-          debug(`> BAD ERROR during ${reqMethod} ${path}:`, err)
-          stream.respond('INTERNAL_ERROR', path, null)
+          debug(`> BAD ERROR during ${requestMethod} ${path}:`, err)
+          stream.respond('INTERNAL_ERROR', requestId, path)
         }
         return
       }
     }
 
-    stream.respond('NOT_FOUND', path, null)
+    stream.respond('NOT_FOUND', requestId, path)
   }
 }
 

--- a/lib/response/swarm.js
+++ b/lib/response/swarm.js
@@ -14,6 +14,7 @@ const routeMatcher = pathMatch({
 
 class Swarm extends ProtocolSwarm {
   handlers = []
+  subscriptions = new Map()
 
   constructor(id) {
     super({
@@ -46,16 +47,21 @@ class Swarm extends ProtocolSwarm {
   _createSubscription(stream, requestId, path) {
     const emitter = new EventEmitter()
     emitter.on('pub', data => stream.respond('PUB_DATA', requestId, path, data))
-    emitter.on('close', () => stream.respond('PUB_CLOSE', requestId, path))
-    emitter.on('error', (data = null) =>
+    emitter.on('close', () => {
+      this.subscriptions.delete(requestId)
+      stream.respond('PUB_CLOSE', requestId, path)
+    })
+    emitter.on('error', (data = null) => {
+      this.subscriptions.delete(requestId)
       stream.respond('PUB_ERROR', requestId, data)
-    )
+    })
 
-    /* FIXME: well, this won't work when a subscription is closed, but the
-        stream is kept alive. rather react to `CLOSE` <id> <path> requests from
-        the client and close the subscription then. */
-    stream.on('close', () => emitter.emit('disconnect'))
+    stream.on('close', () => {
+      this.subscriptions.delete(requestId)
+      emitter.emit('disconnect')
+    })
 
+    this.subscriptions.set(requestId.toString(), emitter)
     return emitter
   }
 
@@ -69,6 +75,24 @@ class Swarm extends ProtocolSwarm {
 
     if (!path.startsWith('/')) {
       stream.respond('BAD_REQUEST', requestId, path)
+      return
+    }
+
+    if (requestMethod === 6) {
+      let subscriptionId
+      try {
+        subscriptionId = Buffer.from(data.requestId).toString()
+      } catch (err) {
+        stream.respond('BAD_REQUEST', requestId, path)
+      }
+
+      if (this.subscriptions.has(subscriptionId)) {
+        const subscription = this.subscriptions.get(subscriptionId)
+        subscription.emit('disconnect')
+        stream.respond('OK', requestId, path)
+      } else {
+        stream.respond('NOT_FOUND', requestId, path)
+      }
       return
     }
 

--- a/lib/schema.proto
+++ b/lib/schema.proto
@@ -14,16 +14,23 @@ enum RequestMethod {
 	POST = 2;
 	PUT = 3;
 	DELETE = 4;
+	SUB = 5;
 }
 
 enum ResponseCode {
 	OK = 1;
-	NOT_FOUND = 2;
-	BAD_REQUEST = 3;
-	CREATED = 4;
-	UPDATED = 5;
-	DELETED = 6;
+	CREATED = 2;
+	UPDATED = 3;
+	DELETED = 4;
+
+	NOT_FOUND = 5;
+	BAD_REQUEST = 6;
 	INTERNAL_ERROR = 7;
+
+	PUB_INIT = 8;
+	PUB_DATA = 9;
+	PUB_CLOSE = 10;
+	PUB_ERROR = 11;
 }
 
 message RequestEvent {

--- a/lib/schema.proto
+++ b/lib/schema.proto
@@ -15,6 +15,7 @@ enum RequestMethod {
 	PUT = 3;
 	DELETE = 4;
 	SUB = 5;
+    CLOSE = 6;
 }
 
 enum ResponseCode {
@@ -35,12 +36,14 @@ enum ResponseCode {
 
 message RequestEvent {
 	required RequestMethod method = 1;
-	required string path = 2;
-	optional bytes data = 3;
+    required bytes id = 2;
+	required string path = 3;
+	optional bytes data = 4;
 }
 
 message ResponseEvent {
 	optional ResponseCode code = 1;
-	required string path = 2;
-	optional bytes data = 3;
+    required bytes id = 2;
+	required string path = 3;
+	optional bytes data = 4;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3028,9 +3028,8 @@
       }
     },
     "hyperswarm-ws": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/hyperswarm-ws/-/hyperswarm-ws-1.2.0.tgz",
-      "integrity": "sha512-J/vivWLJ9NXfn5EPDlq17m4zYTIVo5iK1uOYMLi/DhFAzWdENpE8BwV3Za8MGmtcMXMJ1OYF2Vo63AiPytquQg==",
+      "version": "github:falafeljan/hyperswarm-ws#7bc23cf67143aa872e71e8b03cc1a493ca59f57f",
+      "from": "github:falafeljan/hyperswarm-ws#7bc2",
       "requires": {
         "crypto-browserify": "^3.12.0",
         "debug": "^4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3028,9 +3028,9 @@
       }
     },
     "hyperswarm-ws": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/hyperswarm-ws/-/hyperswarm-ws-1.1.3.tgz",
-      "integrity": "sha512-pGHcQ/oKAoOb2TKGQvFxvlvHfCDxGYskfY7lIHsx2deiP4u3yWJZphky86i5CSpISwN5Yjp1h85+8wW5SvcrBA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hyperswarm-ws/-/hyperswarm-ws-1.2.0.tgz",
+      "integrity": "sha512-J/vivWLJ9NXfn5EPDlq17m4zYTIVo5iK1uOYMLi/DhFAzWdENpE8BwV3Za8MGmtcMXMJ1OYF2Vo63AiPytquQg==",
       "requires": {
         "crypto-browserify": "^3.12.0",
         "debug": "^4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3028,9 +3028,9 @@
       }
     },
     "hyperswarm-ws": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/hyperswarm-ws/-/hyperswarm-ws-1.1.2.tgz",
-      "integrity": "sha512-88qIVB0VdDfM1gpWObLICbh2BZPxTlAH1PFvQWf3Z46z3mRsVWLlxLp0rCibAhDotqNFlbBRFHA16y2ulNGOUA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/hyperswarm-ws/-/hyperswarm-ws-1.1.3.tgz",
+      "integrity": "sha512-pGHcQ/oKAoOb2TKGQvFxvlvHfCDxGYskfY7lIHsx2deiP4u3yWJZphky86i5CSpISwN5Yjp1h85+8wW5SvcrBA==",
       "requires": {
         "crypto-browserify": "^3.12.0",
         "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "node build.js -d | exorcist dist/me2u.js.map > dist/me2u.js",
     "build-min": "node build.js | terser -m -c > dist/me2u.min.js",
     "compile-protocol": "protocol-buffers lib/schema.proto -o lib/messages.js",
+    "start": "node client.js",
     "test": "tape test/*.js"
   },
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "debug": "^4.1.1",
     "hypermerge": "github:automerge/hypermerge#9c720eab",
     "hyperswarm": "^2.3.1",
-    "hyperswarm-ws": "^1.1.2",
+    "hyperswarm-ws": "^1.1.3",
     "length-prefixed-stream": "^2.0.0",
     "path-match": "^1.2.4",
     "protocol-buffers-encodings": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "debug": "^4.1.1",
     "hypermerge": "github:automerge/hypermerge#9c720eab",
     "hyperswarm": "^2.3.1",
-    "hyperswarm-ws": "^1.2.0",
+    "hyperswarm-ws": "github:falafeljan/hyperswarm-ws#7bc2",
     "length-prefixed-stream": "^2.0.0",
     "path-match": "^1.2.4",
     "protocol-buffers-encodings": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "debug": "^4.1.1",
     "hypermerge": "github:automerge/hypermerge#9c720eab",
     "hyperswarm": "^2.3.1",
-    "hyperswarm-ws": "^1.1.3",
+    "hyperswarm-ws": "^1.2.0",
     "length-prefixed-stream": "^2.0.0",
     "path-match": "^1.2.4",
     "protocol-buffers-encodings": "^1.1.0",


### PR DESCRIPTION
closes #21. closes #19.

- [x] add SUB/PUB request/response types
- [x] add API methods for subscribing to annotations
- [x] add request/response identification
- [x] add subscription event handling to peers
- [x] add subscription event handling to clients
- [x] closing subscriptions in the server from a client